### PR TITLE
[추가] 게시물 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/trip/domain/category/CategoryRepository.java
+++ b/src/main/java/com/example/trip/domain/category/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.trip.domain.category;
+
+import com.example.trip.domain.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/example/trip/domain/category/domain/Category.java
+++ b/src/main/java/com/example/trip/domain/category/domain/Category.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"postCategoryList"})
 public class Category extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/trip/domain/category/domain/Category.java
+++ b/src/main/java/com/example/trip/domain/category/domain/Category.java
@@ -3,7 +3,9 @@ package com.example.trip.domain.category.domain;
 import com.example.trip.domain.BaseEntity;
 import com.example.trip.domain.post.domain.PostCategory;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseEntity {
 
     @Id
@@ -28,4 +31,8 @@ public class Category extends BaseEntity {
 
     @OneToMany(mappedBy = "category")
     private List<PostCategory> postCategoryList = new ArrayList<>();    // 카테고리 모음에 대한 리스트
+
+    public Category(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/example/trip/domain/comment/domain/CommentDto.java
+++ b/src/main/java/com/example/trip/domain/comment/domain/CommentDto.java
@@ -1,0 +1,26 @@
+package com.example.trip.domain.comment.domain;
+
+import com.example.trip.domain.member.domain.MemberDto;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class CommentDto {
+
+    private Long id;
+    private String content;
+    private MemberDto member;
+    private LocalDateTime createdTime;
+
+    public static CommentDto of(Comment comment) {
+        return CommentDto.builder()
+                .id(comment.getId())
+                .member(MemberDto.of(comment.getMember()))
+                .content(comment.getContent())
+                .createdTime(comment.getCreatedTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trip/domain/image/ImageRepository.java
+++ b/src/main/java/com/example/trip/domain/image/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.example.trip.domain.image;
+
+import com.example.trip.domain.image.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/example/trip/domain/image/domain/Image.java
+++ b/src/main/java/com/example/trip/domain/image/domain/Image.java
@@ -3,7 +3,9 @@ package com.example.trip.domain.image.domain;
 import com.example.trip.domain.BaseEntity;
 import com.example.trip.domain.post.domain.Post;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 이미지 엔티티
@@ -12,6 +14,7 @@ import lombok.Getter;
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image extends BaseEntity {
 
     @Id
@@ -38,4 +41,7 @@ public class Image extends BaseEntity {
         this.post = null;
     }
 
+    public Image(String imageurl) {
+        this.imageurl = imageurl;
+    }
 }

--- a/src/main/java/com/example/trip/domain/image/domain/Image.java
+++ b/src/main/java/com/example/trip/domain/image/domain/Image.java
@@ -32,4 +32,10 @@ public class Image extends BaseEntity {
         this.post = post;
         post.getImageList().add(this);
     }
+
+    public void clear() {
+        post.getImageList().remove(this);
+        this.post = null;
+    }
+
 }

--- a/src/main/java/com/example/trip/domain/member/domain/Member.java
+++ b/src/main/java/com/example/trip/domain/member/domain/Member.java
@@ -6,9 +6,7 @@ import com.example.trip.domain.comment.domain.Comment;
 import com.example.trip.domain.interaction.domain.Interaction;
 import com.example.trip.domain.post.domain.Post;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +19,9 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
     @Id
@@ -73,4 +73,5 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.imageUrl = imageUrl;
     }
+
 }

--- a/src/main/java/com/example/trip/domain/member/domain/MemberDto.java
+++ b/src/main/java/com/example/trip/domain/member/domain/MemberDto.java
@@ -1,0 +1,19 @@
+package com.example.trip.domain.member.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberDto {
+
+    private String nickname;
+    private String imageUrl;
+
+    public static MemberDto of(Member member) {
+        return MemberDto.builder()
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trip/domain/member/location/LocationRepository.java
+++ b/src/main/java/com/example/trip/domain/member/location/LocationRepository.java
@@ -1,0 +1,7 @@
+package com.example.trip.domain.member.location;
+
+import com.example.trip.domain.member.location.domain.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+}

--- a/src/main/java/com/example/trip/domain/member/location/domain/Location.java
+++ b/src/main/java/com/example/trip/domain/member/location/domain/Location.java
@@ -3,7 +3,7 @@ package com.example.trip.domain.member.location.domain;
 import com.example.trip.domain.BaseEntity;
 import com.example.trip.domain.post.domain.Post;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.math.BigDecimal;
 
@@ -17,6 +17,8 @@ import java.math.BigDecimal;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"post"})
 public class Location extends BaseEntity {
 
     @Id
@@ -43,10 +45,24 @@ public class Location extends BaseEntity {
     @JoinColumn(name = "post_id")
     private Post post;  // 어떤 게시물에 소속될 위치정보인지
 
+    @Builder
+    public Location(BigDecimal latitude, BigDecimal longitude, String address, String telephone, Boolean status) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.address = address;
+        this.telephone = telephone;
+        this.status = status;
+    }
 
     // 연관관계 메소드
     public void setPost(Post post){
         this.post = post;
         post.getLocationList().add(this);
     }
+
+    public void clear() {
+        post.getLocationList().remove(this);
+        this.post = null;
+    }
+
 }

--- a/src/main/java/com/example/trip/domain/member/location/domain/LocationDto.java
+++ b/src/main/java/com/example/trip/domain/member/location/domain/LocationDto.java
@@ -1,0 +1,28 @@
+package com.example.trip.domain.member.location.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class LocationDto {
+    private Long id;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private String address;
+    private String telephone;
+    private Boolean status;
+
+    public static LocationDto of (Location location) {
+        return LocationDto.builder()
+                .id(location.getId())
+                .latitude(location.getLatitude())
+                .longitude(location.getLongitude())
+                .address(location.getAddress())
+                .telephone(location.getTelephone())
+                .status(location.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trip/domain/post/PostRepository.java
+++ b/src/main/java/com/example/trip/domain/post/PostRepository.java
@@ -1,9 +1,14 @@
 package com.example.trip.domain.post;
 
 import com.example.trip.domain.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findAll(Pageable pageable);
+
 }

--- a/src/main/java/com/example/trip/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/trip/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.post.domain.CreatePostRequest;
 import com.example.trip.domain.post.domain.CreatePostResponse;
 import com.example.trip.domain.post.domain.PostDetailsDto;
+import com.example.trip.domain.post.domain.ReadPostsDto;
 import com.example.trip.domain.post.service.PostService;
 import com.example.trip.global.annotation.Login;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,11 @@ public class PostController {
     @ResponseStatus(value = HttpStatus.OK)
     public PostDetailsDto readPostDetails(@PathVariable Long postId) {
         return postService.readPostDetails(postId);
+    }
+
+    @GetMapping
+    public ReadPostsDto readPosts(@RequestParam(defaultValue = "0") int pageNumber, @RequestParam(defaultValue = "10") int pageSize) {
+        return postService.readPosts(pageNumber, pageSize);
     }
 
 }

--- a/src/main/java/com/example/trip/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/trip/domain/post/controller/PostController.java
@@ -1,10 +1,7 @@
 package com.example.trip.domain.post.controller;
 
 import com.example.trip.domain.member.domain.Member;
-import com.example.trip.domain.post.domain.CreatePostRequest;
-import com.example.trip.domain.post.domain.CreatePostResponse;
-import com.example.trip.domain.post.domain.PostDetailsDto;
-import com.example.trip.domain.post.domain.ReadPostsDto;
+import com.example.trip.domain.post.domain.*;
 import com.example.trip.domain.post.service.PostService;
 import com.example.trip.global.annotation.Login;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +31,13 @@ public class PostController {
     @GetMapping
     public ReadPostsDto readPosts(@RequestParam(defaultValue = "0") int pageNumber, @RequestParam(defaultValue = "10") int pageSize) {
         return postService.readPosts(pageNumber, pageSize);
+    }
+
+    @PutMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    public UpdatePostResponse updatePost(@Login Member member, @RequestBody UpdatePostRequest request) {
+        Long postId = postService.updatePost(member.getId(), request);
+        return UpdatePostResponse.of(postId);
     }
 
 }

--- a/src/main/java/com/example/trip/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/trip/domain/post/controller/PostController.java
@@ -3,14 +3,12 @@ package com.example.trip.domain.post.controller;
 import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.post.domain.CreatePostRequest;
 import com.example.trip.domain.post.domain.CreatePostResponse;
+import com.example.trip.domain.post.domain.PostDetailsDto;
 import com.example.trip.domain.post.service.PostService;
 import com.example.trip.global.annotation.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +22,12 @@ public class PostController {
     public CreatePostResponse createPost(@Login Member member, CreatePostRequest request) {
         Long postId = postService.createPost(member.getId(), request);
         return CreatePostResponse.of(postId);
+    }
+
+    @GetMapping("details/{postId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public PostDetailsDto readPostDetails(@PathVariable Long postId) {
+        return postService.readPostDetails(postId);
     }
 
 }

--- a/src/main/java/com/example/trip/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/trip/domain/post/controller/PostController.java
@@ -42,8 +42,8 @@ public class PostController {
 
     @DeleteMapping("/{postId}")
     @ResponseStatus(HttpStatus.OK)
-    public void deletePost(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
-        postService.deletePost(userDetails.getUsername(), postId);
+    public void deletePost(@Login Member member, @PathVariable Long postId) {
+        postService.deletePost(member.getId(), postId);
     }
 
 }

--- a/src/main/java/com/example/trip/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/trip/domain/post/controller/PostController.java
@@ -1,0 +1,29 @@
+package com.example.trip.domain.post.controller;
+
+import com.example.trip.domain.member.domain.Member;
+import com.example.trip.domain.post.domain.CreatePostRequest;
+import com.example.trip.domain.post.domain.CreatePostResponse;
+import com.example.trip.domain.post.service.PostService;
+import com.example.trip.global.annotation.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/post")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public CreatePostResponse createPost(@Login Member member, CreatePostRequest request) {
+        Long postId = postService.createPost(member.getId(), request);
+        return CreatePostResponse.of(postId);
+    }
+
+}

--- a/src/main/java/com/example/trip/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/trip/domain/post/controller/PostController.java
@@ -40,4 +40,10 @@ public class PostController {
         return UpdatePostResponse.of(postId);
     }
 
+    @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void deletePost(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
+        postService.deletePost(userDetails.getUsername(), postId);
+    }
+
 }

--- a/src/main/java/com/example/trip/domain/post/domain/CreatePostRequest.java
+++ b/src/main/java/com/example/trip/domain/post/domain/CreatePostRequest.java
@@ -1,0 +1,19 @@
+package com.example.trip.domain.post.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class CreatePostRequest {
+
+    private String title;
+    private String content;
+    private List<Long> categoryList;
+    private List<Long> locationList;
+    private List<Long> imageList;
+    private List<String> tagList;
+
+}

--- a/src/main/java/com/example/trip/domain/post/domain/CreatePostResponse.java
+++ b/src/main/java/com/example/trip/domain/post/domain/CreatePostResponse.java
@@ -1,0 +1,15 @@
+package com.example.trip.domain.post.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CreatePostResponse {
+
+    private Long postId;
+
+    public static CreatePostResponse of(Long id) {
+        return new CreatePostResponse(id);
+    }
+}

--- a/src/main/java/com/example/trip/domain/post/domain/Post.java
+++ b/src/main/java/com/example/trip/domain/post/domain/Post.java
@@ -47,13 +47,13 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Location> locationList = new ArrayList<>();    // 게시물에 대한 위치 정보 리스트
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Image> imageList = new ArrayList<>();  // 게시물에 등록된 이미지 리스트
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> commentList = new ArrayList<>();  // 게시물에 달린 댓글 리스트
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Interaction> interactionList = new ArrayList<>();  // 게시물에 엮인 상호작용 내역 리스트
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/trip/domain/post/domain/Post.java
+++ b/src/main/java/com/example/trip/domain/post/domain/Post.java
@@ -10,8 +10,6 @@ import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.tag.domain.Tag;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +23,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Post extends BaseEntity {
 
     @Id
@@ -42,11 +41,10 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;  // 게시물 작성자
 
-    @Cascade(CascadeType.ALL)
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostCategory> postCategoryList = new ArrayList<>();    // 게시물에 대한 카테고리 모음 리스트
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Location> locationList = new ArrayList<>();    // 게시물에 대한 위치 정보 리스트
 
     @OneToMany(mappedBy = "post")
@@ -58,17 +56,22 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post")
     private List<Interaction> interactionList = new ArrayList<>();  // 게시물에 엮인 상호작용 내역 리스트
 
-    @Cascade(CascadeType.ALL)
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Tag> tagList = new ArrayList<>();  // 게시물에 대한 태그 리스트
 
     @Builder
     public Post(String title, String content, Member member, List<PostCategory> postCategoryList, List<Location> locationList, List<Image> imageList, List<Tag> tagList) {
         this.title = title;
         this.content = content;
-        this.locationList = locationList;
-        this.imageList = imageList;
-        this.tagList = tagList;
+        for (Location location : locationList) {
+            location.setPost(this);
+        }
+        for (Image image : imageList) {
+            image.setPost(this);
+        }
+        for (Tag tag : tagList) {
+            tag.setPost(this);
+        }
         for (PostCategory postCategory : postCategoryList) {
             postCategory.setPost(this);
         }
@@ -86,4 +89,32 @@ public class Post extends BaseEntity {
         member.getPostList().add(this);
     }
 
+    public void change(String title, String content, List<PostCategory> postCategoryList, List<Location> locationList, List<Image> imageList, List<Tag> tagList) {
+        this.title = title;
+        this.content = content;
+        for (int i = this.locationList.size() - 1; i >= 0; i--) {
+            this.locationList.get(i).clear();
+        }
+        for (Location location : locationList) {
+            location.setPost(this);
+        }
+        for (int i = this.imageList.size() - 1; i >= 0; i--) {
+            this.imageList.get(i).clear();
+        }
+        for (Image image : imageList) {
+            image.setPost(this);
+        }
+        for (int i = this.postCategoryList.size() - 1; i >= 0; i--) {
+            this.postCategoryList.get(i).clear();
+        }
+        for (PostCategory postCategory : postCategoryList) {
+            postCategory.setPost(this);
+        }
+        for (int i = this.tagList.size() - 1; i >= 0; i--) {
+            this.tagList.get(i).clear();
+        }
+        for (Tag tag : tagList) {
+            tag.setPost(this);
+        }
+    }
 }

--- a/src/main/java/com/example/trip/domain/post/domain/Post.java
+++ b/src/main/java/com/example/trip/domain/post/domain/Post.java
@@ -9,9 +9,9 @@ import com.example.trip.domain.member.location.domain.Location;
 import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.tag.domain.Tag;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
     @Id
@@ -42,6 +42,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;  // 게시물 작성자
 
+    @Cascade(CascadeType.ALL)
     @OneToMany(mappedBy = "post")
     private List<PostCategory> postCategoryList = new ArrayList<>();    // 게시물에 대한 카테고리 모음 리스트
 
@@ -57,9 +58,22 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post")
     private List<Interaction> interactionList = new ArrayList<>();  // 게시물에 엮인 상호작용 내역 리스트
 
+    @Cascade(CascadeType.ALL)
     @OneToMany(mappedBy = "post")
-    private List<Tag> tagList = new ArrayList<>();  // 게시물에 대한 테그 리스트
+    private List<Tag> tagList = new ArrayList<>();  // 게시물에 대한 태그 리스트
 
+    @Builder
+    public Post(String title, String content, Member member, List<PostCategory> postCategoryList, List<Location> locationList, List<Image> imageList, List<Tag> tagList) {
+        this.title = title;
+        this.content = content;
+        this.locationList = locationList;
+        this.imageList = imageList;
+        this.tagList = tagList;
+        for (PostCategory postCategory : postCategoryList) {
+            postCategory.setPost(this);
+        }
+        setMember(member);
+    }
 
     // 연관관계 메소드
 
@@ -72,11 +86,4 @@ public class Post extends BaseEntity {
         member.getPostList().add(this);
     }
 
-
-    @Builder
-    public Post(String title, String content, Member member){
-        this.title = title;
-        this.content = content;
-        setMember(member);
-    }
 }

--- a/src/main/java/com/example/trip/domain/post/domain/PostCategory.java
+++ b/src/main/java/com/example/trip/domain/post/domain/PostCategory.java
@@ -13,6 +13,7 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"post"})
 public class PostCategory extends BaseEntity {
 
     @Id
@@ -41,5 +42,10 @@ public class PostCategory extends BaseEntity {
     public void setCategory(Category category){
         this.category = category;
         category.getPostCategoryList().add(this);
+    }
+
+    public void clear() {
+        post.getPostCategoryList().remove(this);
+        this.post = null;
     }
 }

--- a/src/main/java/com/example/trip/domain/post/domain/PostCategory.java
+++ b/src/main/java/com/example/trip/domain/post/domain/PostCategory.java
@@ -3,7 +3,7 @@ package com.example.trip.domain.post.domain;
 import com.example.trip.domain.BaseEntity;
 import com.example.trip.domain.category.domain.Category;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 /**
  * 게시물-카테고리 엔티티
@@ -12,6 +12,7 @@ import lombok.Getter;
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostCategory extends BaseEntity {
 
     @Id
@@ -19,16 +20,17 @@ public class PostCategory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;    // 식별자
 
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;  // 게시물
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;  // 카테고리
 
-
+    public PostCategory(Category category) {
+        this.category = category;
+    }
 
     // 연관관계 메소드
     public void setPost(Post post){

--- a/src/main/java/com/example/trip/domain/post/domain/PostDetailsDto.java
+++ b/src/main/java/com/example/trip/domain/post/domain/PostDetailsDto.java
@@ -1,0 +1,64 @@
+package com.example.trip.domain.post.domain;
+
+import com.example.trip.domain.category.domain.Category;
+import com.example.trip.domain.comment.domain.CommentDto;
+import com.example.trip.domain.image.domain.Image;
+import com.example.trip.domain.interaction.domain.Interaction;
+import com.example.trip.domain.interaction.domain.InteractionType;
+import com.example.trip.domain.member.domain.MemberDto;
+import com.example.trip.domain.member.location.domain.LocationDto;
+import com.example.trip.domain.tag.domain.Tag;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Data
+@Builder
+@ToString
+public class PostDetailsDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private MemberDto member;
+    private List<String> postCategoryList;
+    private List<LocationDto> locationList;
+    private List<String> imageList;
+    private int likes;
+    private int scraps;
+    private List<String> tagList;
+    private List<CommentDto> commentList;
+
+    public static PostDetailsDto of(Post post) {
+        Map<InteractionType, List<Interaction>> interactionTypeMap = post.getInteractionList().stream()
+                .collect(Collectors.groupingBy(Interaction::getType));
+        return PostDetailsDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .member(MemberDto.of(post.getMember()))
+                .postCategoryList(post.getPostCategoryList().stream()
+                        .map(PostCategory::getCategory)
+                        .map(Category::getName)
+                        .toList())
+                .locationList(post.getLocationList().stream()
+                        .map(LocationDto::of)
+                        .toList())
+                .imageList(post.getImageList().stream()
+                        .map(Image::getImageurl)
+                        .toList())
+                .likes(interactionTypeMap.get(InteractionType.LIKE) == null ? 0 : interactionTypeMap.get(InteractionType.LIKE).size())
+                .scraps(interactionTypeMap.get(InteractionType.SCRAP) == null ? 0 : interactionTypeMap.get(InteractionType.SCRAP).size())
+                .tagList(post.getTagList().stream()
+                        .map(Tag::getName)
+                        .toList())
+                .commentList(post.getCommentList().stream()
+                        .map(CommentDto::of)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trip/domain/post/domain/ReadPostDto.java
+++ b/src/main/java/com/example/trip/domain/post/domain/ReadPostDto.java
@@ -1,0 +1,32 @@
+package com.example.trip.domain.post.domain;
+
+import com.example.trip.domain.interaction.domain.InteractionType;
+import com.example.trip.domain.member.domain.MemberDto;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@ToString
+public class ReadPostDto {
+    private Long id;
+    private String title;
+    private MemberDto member;
+    private int likes;
+    private LocalDateTime createdTime;
+
+    public static ReadPostDto of(Post post) {
+        return ReadPostDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .member(MemberDto.of(post.getMember()))
+                .likes((int) post.getInteractionList().stream()
+                        .filter(i -> i.getType().equals(InteractionType.LIKE))
+                        .count())
+                .createdTime(post.getCreatedTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trip/domain/post/domain/ReadPostsDto.java
+++ b/src/main/java/com/example/trip/domain/post/domain/ReadPostsDto.java
@@ -1,0 +1,30 @@
+package com.example.trip.domain.post.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Data
+@Builder
+@ToString
+public class ReadPostsDto {
+    private List<ReadPostDto> postList;
+    private int pageNumber;
+    private int count;
+    private boolean hasNextPage;
+
+    public static ReadPostsDto of(Page<Post> postList) {
+        return ReadPostsDto.builder()
+                .postList(postList.getContent().stream()
+                        .map(ReadPostDto::of)
+                        .toList())
+                .pageNumber(postList.getNumber())
+                .count(postList.getNumberOfElements())
+                .hasNextPage(postList.hasNext())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trip/domain/post/domain/UpdatePostRequest.java
+++ b/src/main/java/com/example/trip/domain/post/domain/UpdatePostRequest.java
@@ -1,0 +1,20 @@
+package com.example.trip.domain.post.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class UpdatePostRequest {
+
+    private Long id;
+    private String title;
+    private String content;
+    private List<Long> categoryList;
+    private List<Long> locationList;
+    private List<Long> imageList;
+    private List<String> tagList;
+
+}

--- a/src/main/java/com/example/trip/domain/post/domain/UpdatePostResponse.java
+++ b/src/main/java/com/example/trip/domain/post/domain/UpdatePostResponse.java
@@ -1,0 +1,16 @@
+package com.example.trip.domain.post.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UpdatePostResponse {
+
+    private Long postId;
+
+    public static UpdatePostResponse of(Long id) {
+        return new UpdatePostResponse(id);
+    }
+
+}

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -92,8 +92,8 @@ public class PostService {
         return post.getId();
     }
 
-    public void deletePost(String username, Long postId) {
-        Member member = memberRepository.findByUserId(username).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
+    public void deletePost(Long userId, Long postId) {
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
 
         if (!isValid(post, member)) {

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -1,0 +1,58 @@
+package com.example.trip.domain.post.service;
+
+import com.example.trip.domain.category.CategoryRepository;
+import com.example.trip.domain.image.ImageRepository;
+import com.example.trip.domain.image.domain.Image;
+import com.example.trip.domain.member.MemberRepository;
+import com.example.trip.domain.member.domain.Member;
+import com.example.trip.domain.member.location.LocationRepository;
+import com.example.trip.domain.member.location.domain.Location;
+import com.example.trip.domain.post.PostRepository;
+import com.example.trip.domain.post.domain.CreatePostRequest;
+import com.example.trip.domain.post.domain.Post;
+import com.example.trip.domain.post.domain.PostCategory;
+import com.example.trip.domain.tag.domain.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostService {
+
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CategoryRepository categoryRepository;
+    private final LocationRepository locationRepository;
+    private final ImageRepository imageRepository;
+
+    public Long createPost(Long userId, CreatePostRequest request) {
+        Member member = memberRepository.findById(userId).orElseThrow(RuntimeException::new);
+        List<Location> locationList = locationRepository.findAllById(request.getLocationList());
+        List<Image> imageList = imageRepository.findAllById(request.getImageList());
+        List<PostCategory> postCategoryList = categoryRepository.findAllById(request.getCategoryList()).stream()
+                .map(PostCategory::new)
+                .toList();
+        List<Tag> tagList = request.getTagList().stream()
+                .map(Tag::new)
+                .toList();
+
+        Post post = Post.builder()
+                .member(member)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .postCategoryList(postCategoryList)
+                .locationList(locationList)
+                .imageList(imageList)
+                .tagList(tagList)
+                .build();
+
+        postRepository.save(post);
+
+        return post.getId();
+    }
+
+}

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -8,12 +8,13 @@ import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.member.location.LocationRepository;
 import com.example.trip.domain.member.location.domain.Location;
 import com.example.trip.domain.post.PostRepository;
-import com.example.trip.domain.post.domain.CreatePostRequest;
-import com.example.trip.domain.post.domain.Post;
-import com.example.trip.domain.post.domain.PostCategory;
-import com.example.trip.domain.post.domain.PostDetailsDto;
+import com.example.trip.domain.post.domain.*;
 import com.example.trip.domain.tag.domain.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,4 +61,12 @@ public class PostService {
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
         return PostDetailsDto.of(post);
     }
+
+    public ReadPostsDto readPosts(int pageNumber, int pageSize) {
+        Sort sort = Sort.by("createdTime").descending();
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
+        Page<Post> postList = postRepository.findAll(pageRequest);
+        return ReadPostsDto.of(postList);
+    }
+
 }

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -92,8 +92,18 @@ public class PostService {
         return post.getId();
     }
 
+    public void deletePost(String username, Long postId) {
+        Member member = memberRepository.findByUserId(username).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
+
+        if (!isValid(post, member)) {
+            throw new RuntimeException("허용되지 않는 요청입니다.");
+        }
+
+        postRepository.delete(post);
+    }
+
     private boolean isValid(Post post, Member member) {
         return post.getMember().equals(member);
     }
-
 }

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -11,6 +11,7 @@ import com.example.trip.domain.post.PostRepository;
 import com.example.trip.domain.post.domain.CreatePostRequest;
 import com.example.trip.domain.post.domain.Post;
 import com.example.trip.domain.post.domain.PostCategory;
+import com.example.trip.domain.post.domain.PostDetailsDto;
 import com.example.trip.domain.tag.domain.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,4 +56,8 @@ public class PostService {
         return post.getId();
     }
 
+    public PostDetailsDto readPostDetails(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
+        return PostDetailsDto.of(post);
+    }
 }

--- a/src/main/java/com/example/trip/domain/tag/domain/Tag.java
+++ b/src/main/java/com/example/trip/domain/tag/domain/Tag.java
@@ -3,7 +3,9 @@ package com.example.trip.domain.tag.domain;
 import com.example.trip.domain.BaseEntity;
 import com.example.trip.domain.post.domain.Post;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 테그 엔티티
@@ -12,6 +14,7 @@ import lombok.Getter;
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag extends BaseEntity {
 
     @Id
@@ -26,6 +29,9 @@ public class Tag extends BaseEntity {
     @JoinColumn(name = "post_id")
     private Post post;  // 테그가 달릴 게시물
 
+    public Tag(String name) {
+        this.name = name;
+    }
 
     // 연관관계 메소드
     public void setPost(Post post){

--- a/src/main/java/com/example/trip/domain/tag/domain/Tag.java
+++ b/src/main/java/com/example/trip/domain/tag/domain/Tag.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * 테그 엔티티
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"post"})
 public class Tag extends BaseEntity {
 
     @Id
@@ -38,4 +40,10 @@ public class Tag extends BaseEntity {
         this.post = post;
         post.getTagList().add(this);
     }
+
+    public void clear() {
+        post.getTagList().remove(this);
+        this.post = null;
+    }
+
 }

--- a/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
@@ -1,0 +1,113 @@
+package com.example.trip.domain.post.service;
+
+import com.example.trip.domain.category.CategoryRepository;
+import com.example.trip.domain.category.domain.Category;
+import com.example.trip.domain.member.MemberRepository;
+import com.example.trip.domain.post.PostRepository;
+import com.example.trip.domain.post.domain.CreatePostRequest;
+import com.example.trip.domain.post.domain.Post;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Nested
+    class 게시물서비스에서_게시물을_저장한_뒤 {
+
+        @Nested
+        class 존재하는_아이디로_조회하면 {
+
+            @Test
+            public void 해당하는_엔티티가_조회된다() throws Exception {
+                // given
+                Category category1 = new Category("category1");
+                Category category2 = new Category("category2");
+                Category category3 = new Category("category3");
+
+                categoryRepository.save(category1);
+                categoryRepository.save(category2);
+                categoryRepository.save(category3);
+
+                CreatePostRequest request = CreatePostRequest.builder()
+                        .title("test title")
+                        .content("test content")
+                        .locationList(List.of(1L, 2L, 3L, 4L, 5L))
+                        .categoryList(List.of(category1.getId(), category2.getId(), category3.getId()))
+                        .imageList(List.of(1L, 2L))
+                        .tagList(List.of("tag1", "tag2"))
+                        .build();
+
+                // when
+                Long postId = postService.createPost("user", request);
+                Post findOne = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("NO ENTITY"));
+
+                // then
+                Assertions.assertThat(findOne.getId()).isEqualTo(postId);
+
+            }
+        }
+
+        @Nested
+        class 존재하지않는_아이디로_조회하면 {
+
+            @Test
+            public void 예외가_발생한다() throws Exception {
+                // given
+                Category category1 = new Category("category1");
+                Category category2 = new Category("category2");
+                Category category3 = new Category("category3");
+
+                categoryRepository.save(category1);
+                categoryRepository.save(category2);
+                categoryRepository.save(category3);
+
+                CreatePostRequest request = CreatePostRequest.builder()
+                        .title("test title")
+                        .content("test content")
+                        .locationList(List.of(1L, 2L, 3L, 4L, 5L))
+                        .categoryList(List.of(category1.getId(), category2.getId(), category3.getId()))
+                        .imageList(List.of(1L, 2L))
+                        .tagList(List.of("tag1", "tag2"))
+                        .build();
+
+                // when
+                Long postId = postService.createPost("user", request);
+
+                // then
+                Assertions.assertThatThrownBy(() -> postRepository.findById(postId + 2).orElseThrow(RuntimeException::new))
+                        .isInstanceOf(RuntimeException.class);
+
+            }
+        }
+    }
+
+
+
+
+}

--- a/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
@@ -2,21 +2,24 @@ package com.example.trip.domain.post.service;
 
 import com.example.trip.domain.category.CategoryRepository;
 import com.example.trip.domain.category.domain.Category;
+import com.example.trip.domain.image.domain.Image;
 import com.example.trip.domain.member.MemberRepository;
 import com.example.trip.domain.member.domain.Member;
+import com.example.trip.domain.member.location.LocationRepository;
+import com.example.trip.domain.member.location.domain.Location;
 import com.example.trip.domain.post.PostRepository;
-import com.example.trip.domain.post.domain.CreatePostRequest;
-import com.example.trip.domain.post.domain.Post;
-import com.example.trip.domain.post.domain.PostDetailsDto;
-import com.example.trip.domain.post.domain.ReadPostsDto;
+import com.example.trip.domain.post.domain.*;
+import com.example.trip.domain.tag.domain.Tag;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,6 +43,9 @@ class PostServiceTest {
 
     @Autowired
     CategoryRepository categoryRepository;
+
+    @Autowired
+    LocationRepository locationRepository;
 
     @Nested
     class 게시물서비스에서_게시물을_저장한_뒤 {
@@ -118,6 +124,130 @@ class PostServiceTest {
 
             }
         }
+
+        @Nested
+        class 작성자가_업데이트_요청하면 {
+
+            static String username = "user";
+            static String newTitle = "new title";
+            static String newContent = "new content";
+            static List<Long> newCategoryList;
+            static List<Long> newLocationList;
+            static List<Long> newImageList;
+            static List<String> newTagList;
+
+            @Test
+            public void 정상적으로_수행된다() throws Exception {
+                // given
+                Location location1 = new Location(new BigDecimal(10), new BigDecimal(20), "서울 동작구 상도로 369", "123-4567", true);
+                Location location2 = new Location(new BigDecimal(11), new BigDecimal(21), "서울 동작구 상도로 369", "123-4567", true);
+                Location location3 = new Location(new BigDecimal(12), new BigDecimal(22), "서울 동작구 상도로 369", "123-4567", true);
+                Location location4 = new Location(new BigDecimal(13), new BigDecimal(23), "서울 동작구 상도로 369", "123-4567", true);
+                Location location5 = new Location(new BigDecimal(14), new BigDecimal(24), "서울 동작구 상도로 369", "123-4567", true);
+
+                locationRepository.saveAll(List.of(location1, location2, location3, location4, location5));
+
+                Category category1 = new Category("category1");
+                Category category2 = new Category("category2");
+                Category category3 = new Category("category3");
+
+                categoryRepository.save(category1);
+                categoryRepository.save(category2);
+                categoryRepository.save(category3);
+
+                CreatePostRequest request1 = CreatePostRequest.builder()
+                        .title("test title1")
+                        .content("test content1")
+                        .locationList(List.of(1L, 2L, 3L, 4L, 5L))
+                        .categoryList(List.of(category1.getId(), category2.getId(), category3.getId()))
+                        .imageList(List.of(1L, 2L))
+                        .tagList(List.of("tag1", "tag2"))
+                        .build();
+
+                Member user = memberRepository.findByNickname(username);
+
+                Long postId1 = postService.createPost(user.getId(), request1);
+
+                newLocationList = List.of(2L, 3L);
+                newCategoryList = List.of(category3.getId());
+                newImageList = List.of(2L, 3L);
+                newTagList = List.of("tag2", "tag3");
+
+                // when
+                Post post = postRepository.findById(postId1).orElseThrow(() -> new RuntimeException("존재하지 않는 엔티티입니다."));
+//                System.out.println("post = " + post);
+
+                UpdatePostRequest request = UpdatePostRequest.builder()
+                        .id(postId1)
+                        .title(newTitle)
+                        .content(newContent)
+                        .categoryList(newCategoryList)
+                        .locationList(newLocationList)
+                        .imageList(newImageList)
+                        .tagList(newTagList)
+                        .build();
+
+                Member member = memberRepository.findByNickname(username);
+                Long updatePostId = postService.updatePost(member.getId(), request);
+
+                Post updatePost = postRepository.findById(updatePostId).orElseThrow(() -> new RuntimeException("엔티티가 존재하지 않습니다."));
+//                for (PostCategory postCategory : expectPostCategoryList) {
+//                    System.out.println("postCategory = " + postCategory);
+//                }
+
+                em.flush();
+                em.clear();
+                List<Tag> expectTagList = em.createQuery(
+                                "select t from Tag t" +
+                                        " where t.name in :newTagList",
+                                Tag.class)
+                        .setParameter("newTagList", newTagList)
+                        .getResultList();
+
+                List<PostCategory> expectPostCategoryList = em.createQuery(
+                                "select pc from PostCategory pc" +
+                                        " where pc.category.id in :newCategoryList",
+                                PostCategory.class)
+                        .setParameter("newCategoryList", newCategoryList)
+                        .getResultList();
+
+                List<Location> expectLocationList = em.createQuery(
+                                "select l from Location l" +
+                                        " where l.id in :newLocationList",
+                                Location.class)
+                        .setParameter("newLocationList", newLocationList)
+                        .getResultList();
+
+                List<Image> expectImageList = em.createQuery(
+                                "select i from Image i" +
+                                        " where i.id in :newImageList",
+                                Image.class)
+                        .setParameter("newImageList", newImageList)
+                        .getResultList();
+
+                Post post1 = postRepository.findById(updatePostId).orElseThrow();
+
+                // then
+                Assertions.assertThat(post1.getTitle()).isEqualTo(newTitle);
+                Assertions.assertThat(post1.getContent()).isEqualTo(newContent);
+                Assertions.assertThat(post1.getPostCategoryList()).containsAll(expectPostCategoryList);
+                Assertions.assertThat(post1.getLocationList()).containsAll(expectLocationList);
+                Assertions.assertThat(post1.getImageList()).containsAll(expectImageList);
+                Assertions.assertThat(post1.getTagList()).containsAll(expectTagList);
+
+//                System.out.println("updatePost = " + updatePost);
+            }
+
+
+        }
+
+        @Nested
+        class 작성자가_아닌_경우 {
+
+            @Test
+            public void 예외가_발생한다() throws Exception {
+            }
+        }
     }
 
     @Test
@@ -149,8 +279,10 @@ class PostServiceTest {
                 .tagList(List.of("tag3"))
                 .build();
 
-        Long postId1 = postService.createPost("user", request1);
-        Long postId2 = postService.createPost("user", request2);
+        Member user = memberRepository.findByNickname("user");
+
+        Long postId1 = postService.createPost(user.getId(), request1);
+        Long postId2 = postService.createPost(user.getId(), request2);
 
         int pageNumber = 0;
         int pageSize = 10;

--- a/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
@@ -290,14 +290,15 @@ class PostServiceTest {
                         .tagList(List.of("tag1", "tag2"))
                         .build();
 
-                Long postId1 = postService.createPost("user", request1);
+                Member user = memberRepository.findByNickname("user");
+                Long postId1 = postService.createPost(user.getId(), request1);
                 Post post = postRepository.findById(postId1).orElseThrow(() -> new RuntimeException(""));
                 List<Long> postCategoryIds = post.getPostCategoryList().stream()
                         .map(PostCategory::getId)
                         .collect(Collectors.toList());
 
                 // when
-                postService.deletePost("user", postId1);
+                postService.deletePost(user.getId(), postId1);
 
                 // then
                 Assertions.assertThatThrownBy(() -> postRepository.findById(postId1).orElseThrow(() -> new RuntimeException("존재하지 않는 엔티티")))

--- a/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
@@ -8,6 +8,7 @@ import com.example.trip.domain.post.PostRepository;
 import com.example.trip.domain.post.domain.CreatePostRequest;
 import com.example.trip.domain.post.domain.Post;
 import com.example.trip.domain.post.domain.PostDetailsDto;
+import com.example.trip.domain.post.domain.ReadPostsDto;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -118,7 +120,54 @@ class PostServiceTest {
         }
     }
 
+    @Test
+    public void 게시물_리스트_조회_테스트() throws Exception {
+        // given
+        Category category1 = new Category("category1");
+        Category category2 = new Category("category2");
+        Category category3 = new Category("category3");
 
+        categoryRepository.save(category1);
+        categoryRepository.save(category2);
+        categoryRepository.save(category3);
 
+        CreatePostRequest request1 = CreatePostRequest.builder()
+                .title("test title1")
+                .content("test content1")
+                .locationList(List.of(1L, 2L, 3L, 4L, 5L))
+                .categoryList(List.of(category1.getId(), category2.getId(), category3.getId()))
+                .imageList(List.of(1L, 2L))
+                .tagList(List.of("tag1", "tag2"))
+                .build();
+
+        CreatePostRequest request2 = CreatePostRequest.builder()
+                .title("test title2")
+                .content("test content2")
+                .locationList(List.of())
+                .categoryList(List.of(category1.getId(), category2.getId(), category3.getId()))
+                .imageList(List.of())
+                .tagList(List.of("tag3"))
+                .build();
+
+        Long postId1 = postService.createPost("user", request1);
+        Long postId2 = postService.createPost("user", request2);
+
+        int pageNumber = 0;
+        int pageSize = 10;
+
+        // when
+        ReadPostsDto readPostsDto = postService.readPosts(pageNumber, pageSize);
+        List<Post> posts = postRepository.findAll();
+
+        // then
+        Assertions.assertThat(readPostsDto.getCount()).isEqualTo(posts.size());
+        Assertions.assertThat(readPostsDto.getPageNumber()).isEqualTo(pageNumber);
+        Assertions.assertThat(posts).extracting(
+                        Post::getId,
+                        Post::getTitle)
+                .contains(
+                        Tuple.tuple(posts.get(0).getId(), posts.get(0).getTitle()),
+                        Tuple.tuple(posts.get(1).getId(), posts.get(1).getTitle()));
+    }
 
 }

--- a/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.example.trip.domain.post.service;
 import com.example.trip.domain.category.CategoryRepository;
 import com.example.trip.domain.category.domain.Category;
 import com.example.trip.domain.member.MemberRepository;
+import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.post.PostRepository;
 import com.example.trip.domain.post.domain.CreatePostRequest;
 import com.example.trip.domain.post.domain.Post;
@@ -63,8 +64,10 @@ class PostServiceTest {
                         .tagList(List.of("tag1", "tag2"))
                         .build();
 
+                Member user = memberRepository.findByNickname("user");
+
                 // when
-                Long postId = postService.createPost("user", request);
+                Long postId = postService.createPost(user.getId(), request);
                 Post findOne = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("NO ENTITY"));
 
                 // then
@@ -96,8 +99,10 @@ class PostServiceTest {
                         .tagList(List.of("tag1", "tag2"))
                         .build();
 
+                Member user = memberRepository.findByNickname("user");
+
                 // when
-                Long postId = postService.createPost("user", request);
+                Long postId = postService.createPost(user.getId(), request);
 
                 // then
                 Assertions.assertThatThrownBy(() -> postRepository.findById(postId + 2).orElseThrow(RuntimeException::new))

--- a/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/trip/domain/post/service/PostServiceTest.java
@@ -7,6 +7,7 @@ import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.post.PostRepository;
 import com.example.trip.domain.post.domain.CreatePostRequest;
 import com.example.trip.domain.post.domain.Post;
+import com.example.trip.domain.post.domain.PostDetailsDto;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -69,9 +70,13 @@ class PostServiceTest {
                 // when
                 Long postId = postService.createPost(user.getId(), request);
                 Post findOne = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("NO ENTITY"));
+                PostDetailsDto postDetails = postService.readPostDetails(postId);
 
                 // then
                 Assertions.assertThat(findOne.getId()).isEqualTo(postId);
+                Assertions.assertThat(findOne.getId()).isEqualTo(postDetails.getId());
+                Assertions.assertThat(findOne.getTitle()).isEqualTo(postDetails.getTitle());
+                Assertions.assertThat(findOne.getContent()).isEqualTo(postDetails.getContent());
 
             }
         }
@@ -103,6 +108,7 @@ class PostServiceTest {
 
                 // when
                 Long postId = postService.createPost(user.getId(), request);
+                PostDetailsDto postDetails = postService.readPostDetails(postId);
 
                 // then
                 Assertions.assertThatThrownBy(() -> postRepository.findById(postId + 2).orElseThrow(RuntimeException::new))


### PR DESCRIPTION
- 게시물 등록 기능 구현
	- Tag 를 제외한 Location, Image, Category 는 이미 저장되어 있는 것으로 간주하여 id 값을 받습니다.
- 게시물 조회(리스트, 상세)
- 게시물 수정 기능 구현
	- 1 : N 연관관계를 갖는 Tag 와 PostCategory 에 대해 연관관계가 끊어질 때 삭제되도록 설정하였습니다.
	- Image, Interaction, Comment 와의 관계는 해당 도메인의 구현 이후 수정하겠습니다.
- 게시물 삭제 기능 구현
	- 게시물 삭제 시 연관된 엔티티가 모두 삭제됩니다(PostCategory, Location, Image, Comment, Interaction, Tag).