### PR TITLE
[수정] 게시물 관리 기능 오류

### DIFF
--- a/src/main/java/com/example/trip/domain/image/domain/Image.java
+++ b/src/main/java/com/example/trip/domain/image/domain/Image.java
@@ -22,7 +22,7 @@ public class Image extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;   // 식별자
 
-    @Column(nullable = false)
+    @Column(length = 2047)
     private String imageurl;    // 이미지 링크
 
     private String imageKey;

--- a/src/main/java/com/example/trip/domain/post/domain/Post.java
+++ b/src/main/java/com/example/trip/domain/post/domain/Post.java
@@ -5,7 +5,6 @@ import com.example.trip.domain.BaseEntity;
 import com.example.trip.domain.comment.domain.Comment;
 import com.example.trip.domain.image.domain.Image;
 import com.example.trip.domain.interaction.domain.Interaction;
-import com.example.trip.domain.location.domain.Location;
 import com.example.trip.domain.location.domain.LocationPath;
 import com.example.trip.domain.member.domain.Member;
 import com.example.trip.domain.tag.domain.Tag;
@@ -110,6 +109,11 @@ public class Post extends BaseEntity {
     public void delete(Interaction interaction) {
         this.interactionList.remove(interaction);
         interaction.delete();
+    }
+
+    public void deleteLocationPath() {
+        locationPath.setPost(null);
+        locationPath = null;
     }
 
 }

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -51,6 +51,10 @@ public class PostService {
                 .map(PostCategory::new)
                 .toList();
 
+        if (!validate(locationPath, member)) {
+            throw new RuntimeException("허용되지 않는 요청입니다.");
+        }
+
         Post post = Post.builder()
                 .member(member)
                 .title(request.getTitle())
@@ -91,6 +95,9 @@ public class PostService {
                 .toList();
 //        postCategoryRepository.save()
 
+        if (!validate(locationPath, member)) {
+            throw new RuntimeException("허용되지 않는 요청입니다.");
+        }
 
         if (!isValid(post, member)) {
             throw new RuntimeException("허용되지 않는 요청입니다.");
@@ -137,6 +144,13 @@ public class PostService {
         return post.getImageList().stream()
                 .map(image -> ImageDto.of(image.getId(), imageManager.createSignedUrlForString(image.getImageKey())))
                 .toList();
+    }
+
+    public boolean validate(LocationPath locationPath, Member member) {
+        if (locationPath.getMember().getId().equals(member.getId())) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/example/trip/domain/post/service/PostService.java
+++ b/src/main/java/com/example/trip/domain/post/service/PostService.java
@@ -108,6 +108,7 @@ public class PostService {
         if (!isValid(post, member)) {
             throw new RuntimeException("허용되지 않는 요청입니다.");
         }
+        post.deleteLocationPath();
         postRepository.delete(post);
     }
 


### PR DESCRIPTION
- 게시물 삭제시 location_path와 post의 연관관계를 끊어 게시물만 삭제하도록 구현
- 게시물 등록 및 수정 시 location_path의 소유자와 post의 소유자가 동일한지 검증하는 기능 추가